### PR TITLE
Switched to color interoplate for stack3D

### DIFF
--- a/src/js/components/StackViewer.react.js
+++ b/src/js/components/StackViewer.react.js
@@ -146,24 +146,28 @@ var StackViewer = React.createClass({
 
             // !! hacks into proofreader status for now
             var valstat = this.getStat(substacks[sid], comptype);
-            var statusval = 0;
-            if (colorrange[2] > 0.000001) {
-                statusval = Math.floor((valstat - colorrange[0])/colorrange[2]);
-            }
-            if (this.state.metric == "rand") {
-                statusval = NumColors - statusval;
-            }
-            if (statusval == NumColors) {
-                statusval -= 1;
-            }
+            // var statusval = 0;
+            // if (colorrange[2] > 0.000001) {
+            //     statusval = Math.floor((valstat - colorrange[0])/colorrange[2]);
+            // }
+            // if (this.state.metric == "rand") {
+            //     statusval = NumColors - statusval;
+            // }
+            // if (statusval == NumColors) {
+            //     statusval -= 1;
+            // }
 
-            subobj["status"] = statusval;
+            // subobj["status"] = statusval;
+            subobj["status"] = valstat;
             payload["substacks"].push(subobj);
         }
 
         payload["colors"] = this.loadColors(colorrange, comptype);
-	payload["element"] = '#stack_roi';
+	    payload["element"] = '#stack_roi';
         payload["modal"] = true;
+        payload["metadataTop"] = true;
+        payload["colorInterpolate"] = ['White', 'Yellow', 'aquamarine', 'deepskyblue', 'mediumorchid'];
+
 
         // make dimensions larger by 2x to zoom out
         payload["stackDimensions"] = [(maxx-minx)*2,(maxy-miny)*2,(maxz-minz)*2];


### PR DESCRIPTION
I've switched it from using discrete colors to using interpolated colors. I commented out all of the code that put your statsval into categories, and just left the values raw to go into the stack3d. 

I put together a color scheme that I think works. I used all relatively light colors, because those are easier to differentiate between and I didn't want to switch color schemes between rand and VI. But it's pretty easy to play around with color schemes here are some options:
payload["colorInterpolate"] = "RdYlBu";
payload["colorInterpolate"] = "YlGnBu";
payload["colorInterpolate"] = ["white", "yellow", "red", "black"];
payload["colorInterpolate"] = ["#ffffff', "#0080ff", "#000000"];

Here is the link to show what color words/scales are available, but you can always use an array of hex codes. https://github.com/gka/chroma.js/wiki/Predefined-Colors
